### PR TITLE
Closed menu items may not render the nextElementSibling until opened

### DIFF
--- a/src/getStories.js
+++ b/src/getStories.js
@@ -82,7 +82,7 @@ function getStories() {
     });
 
     function getClosedMenus(menuItems) {
-      return menuItems.filter(menuItem => !menuItem.nextElementSibling.children[0]);
+      return menuItems.filter(menuItem => !menuItem.nextElementSibling || !menuItem.nextElementSibling.children[0]);
     }
 
     function openMenus(menuItems) {


### PR DESCRIPTION
Closed
![image](https://user-images.githubusercontent.com/13340489/51096658-f6cb8b00-1822-11e9-9ebd-d190d9e5741a.png)

Opened
![image](https://user-images.githubusercontent.com/13340489/51096674-25496600-1823-11e9-993b-0fd1a70b5d75.png)
