### PR TITLE
TestResultsFormatter in eyes-sdk-core has changed its API

### DIFF
--- a/src/processResults.js
+++ b/src/processResults.js
@@ -16,7 +16,7 @@ function processResults({results = [], totalTime, concurrency}) {
   if (testResults.length > 0) {
     outputStr += '[EYES: TEST RESULTS]:\n';
     testResults.forEach(result => {
-      formatter.addResults(result);
+      formatter.addTestResults(result);
 
       const storyTitle = `${result.getName()} [${result.getHostDisplaySize().toString()}] - `;
 


### PR DESCRIPTION
TestResultsFormatter in eyes-sdk-core has changed it's API. `addResults` has been renamed to `addTestResults`

eyes-storybook v2.3.4 currently fails at the end of a run when the tests results are output with error "formatter.addResults is not a function"

![image](https://user-images.githubusercontent.com/13340489/51448411-75787900-1d8b-11e9-9f23-37b48bad153b.png)
