### PR TITLE
Handle storiesOf containing spaces

### DIFF
--- a/src/getStories.js
+++ b/src/getStories.js
@@ -138,14 +138,17 @@ async function getStories() {
         return menuItems.map(item => item.textContent).join('\n');
       }
 
+      function getTitle(id) {
+        const anchorElement = document.getElementById(id);
+        return anchorElement ? anchorElement.title : '';
+      }
+
       function getKindFromAnchor(anchor) {
         const idParts = anchor.id.match(/(\S+)--.+/)[1].split('-');
         return idParts.reduce(
           (kind, id) => {
             kind.aggId = kind.aggId ? `${kind.aggId}-${id}` : id;
-            kind.aggKind = `${kind.aggKind ? kind.aggKind + '/' : ''}${
-              document.getElementById(kind.aggId).title
-            }`;
+            kind.aggKind = `${kind.aggKind ? kind.aggKind + '/' : ''}${getTitle(kind.aggId)}`;
             return kind;
           },
           {aggId: null, aggKind: null},

--- a/test/e2e/eyes-storybook.e2e.test.js
+++ b/test/e2e/eyes-storybook.e2e.test.js
@@ -40,6 +40,7 @@ describe('eyes-storybook', () => {
       {name: 'Nested/Component: story 1.1', isPassed: true},
       {name: 'Nested/Component: story 1.2', isPassed: true},
       {name: 'Nested: story 1', isPassed: true},
+      {name: 'Component with spaces: story 1', isPassed: true},
     ]);
   });
 });

--- a/test/fixtures/appWithStorybook/index.js
+++ b/test/fixtures/appWithStorybook/index.js
@@ -25,3 +25,6 @@ storiesOf('Nested/Component', module)
   .add('story 1.1', () => <div>story 1.1</div>)
   .add('story 1.2', () => <div>story 1.2</div>);
 
+storiesOf('Component with spaces', module)
+  .add('story 1', () => <div>story 1</div>);
+  


### PR DESCRIPTION
Currently Storybook version 5 crashes if `storiesOf` contains spaces

This PR fixes the issue by only appending to the title if a valid anchor has been selected by id