### PR TITLE
fix v5 storybook

### DIFF
--- a/src/getStories.js
+++ b/src/getStories.js
@@ -116,12 +116,17 @@ async function getStories() {
       console.log(`returning ${stories.length} stories.`);
       return stories;
 
-      function getStoriesFromAnchors(anchors, kind = '') {
+      function getStoriesFromAnchors(anchors) {
         return Array.from(anchors).reduce((acc, anchor) => {
-          const anchorKind = kind.length ? `${kind}/${anchor.innerText}` : anchor.innerText;
-          const stories = isLeafAnchor(anchor)
-            ? [{name: anchor.innerText, kind: kind}]
-            : getStoriesFromAnchor(anchor, anchorKind);
+          let stories;
+
+          if (isLeafAnchor(anchor)) {
+            const [ , kind, name] = anchor.id.match(/explorer(\S+)--(\S+)/)
+            stories = [{ kind, name }]
+          } else {
+            stories = getStoriesFromAnchor(anchor);
+          }
+
           acc = acc.concat(stories);
           return acc;
         }, []);

--- a/src/getStories.js
+++ b/src/getStories.js
@@ -121,8 +121,8 @@ async function getStories() {
           let stories;
 
           if (isLeafAnchor(anchor)) {
-            const [ , kind, name] = anchor.id.match(/explorer(\S+)--(\S+)/)
-            stories = [{ kind, name }]
+            const [, kind, name] = anchor.id.match(/explorer(\S+)--(\S+)/);
+            stories = [{kind, name}];
           } else {
             stories = getStoriesFromAnchor(anchor);
           }


### PR DESCRIPTION
this package was parsing the name and kind in a storybook v5 incompatible way.

used to produce:

`http://localhost:6006/iframe.html?selectedKind=Welcome&selectedStory=Intro`

now it produces a url that works

`http://localhost:6006/iframe.html?selectedKind=getting-started-welcome&selectedStory=intro`

without this change I get the following 

<img width="1519" alt="Screen Shot 2019-04-12 at 9 48 14 PM" src="https://user-images.githubusercontent.com/1192452/56074761-b7063800-5d6c-11e9-9814-353a11235fcc.png">


