### PR TITLE
Change waitBeforeScreenshots to use Puppeteer waitFor() rather than delay

### DIFF
--- a/src/generateConfig.js
+++ b/src/generateConfig.js
@@ -10,9 +10,6 @@ function generateConfig({argv = {}, defaultConfig = {}, externalConfigParams = [
   const config = ConfigUtils.getConfig({configPath, configParams});
   const argvConfig = pick(argv, configParams);
   const result = Object.assign({}, defaultConfig, config, argvConfig);
-  if (result.waitBeforeScreenshots) {
-    result.waitBeforeScreenshots = Number(result.waitBeforeScreenshots);
-  }
   return result;
 }
 

--- a/src/getStoryData.js
+++ b/src/getStoryData.js
@@ -1,10 +1,11 @@
 'use strict';
 const {presult} = require('@applitools/functional-commons');
 const {ArgumentGuard} = require('@applitools/eyes-common');
-const {delay} = require('@applitools/functional-commons');
 
 function makeGetStoryData({logger, processPageAndSerialize, waitBeforeScreenshots}) {
-  ArgumentGuard.greaterThanOrEqualToZero(waitBeforeScreenshots, 'waitBeforeScreenshots', true);
+  if (typeof waitBeforeScreenshots === 'number') {
+    ArgumentGuard.greaterThanOrEqualToZero(waitBeforeScreenshots, 'waitBeforeScreenshots', true);
+  }
 
   return async function getStoryData({url, page}) {
     logger.log(`getting data from story ${url}`);
@@ -12,7 +13,7 @@ function makeGetStoryData({logger, processPageAndSerialize, waitBeforeScreenshot
     if (err) {
       logger.log(`error navigating to story ${url}`, err);
     }
-    await delay(waitBeforeScreenshots);
+    await page.waitFor(waitBeforeScreenshots);
     const {resourceUrls, blobs, frames, cdt} = await page.evaluate(processPageAndSerialize);
     const resourceContents = blobs.map(({url, type, value}) => ({
       url,

--- a/test/unit/getStoryData.test.js
+++ b/test/unit/getStoryData.test.js
@@ -2,12 +2,12 @@
 const {describe, it} = require('mocha');
 const {expect} = require('chai');
 const makeGetStoryData = require('../../src/getStoryData');
-const {promisify: p} = require('util');
 
 describe('getStoryData', () => {
   it('works', async () => {
     const page = {
       goto: async () => {},
+      waitFor: async () => {},
       evaluate: func => Promise.resolve(func()),
     };
     const valueBuffer = Buffer.from('value');
@@ -35,10 +35,8 @@ describe('getStoryData', () => {
   it('waits waitBeforeScreenshots before taking the screen shot', async () => {
     const page = {
       goto: async () => {},
-      evaluate: func =>
-        ready
-          ? Promise.resolve(func())
-          : Promise.reject('did not wait enough before taking snapshot'),
+      waitFor: async () => {},
+      evaluate: func => Promise.resolve(func()),
     };
 
     const valueBuffer = Buffer.from('value');
@@ -56,8 +54,6 @@ describe('getStoryData', () => {
       waitBeforeScreenshots: 1100,
     });
 
-    let ready;
-    p(setTimeout)(1000).then(() => (ready = true));
     const {resourceUrls, resourceContents, cdt} = await getStoryData({
       url: 'url',
       page,
@@ -66,14 +62,6 @@ describe('getStoryData', () => {
     expect(resourceUrls).to.eql(['url1']);
     expect(resourceContents).to.eql(expectedResourceContents);
     expect(cdt).to.equal('cdt');
-  });
-
-  it('throws when getting an invalid waitBeforeScreenshots', async () => {
-    expect(() =>
-      makeGetStoryData({
-        waitBeforeScreenshots: '1100',
-      }),
-    ).to.throw('waitBeforeScreenshots');
   });
 
   it('throws when getting a negative waitBeforeScreenshots', async () => {


### PR DESCRIPTION
We have a use case where our Storybook wraps components with a mock Apollo provider. This ensures that all Query components displayed in the Storybook automatically render with data returned from a mock schema.

The Apollo Query API however can only run asynchronously. This means the Component will always render in a "loading" state before doing a follow up render of the loaded state of the Component which is what we would like to snapshot with Applitools.

Currently waitBeforeScreenshots gives us the ability to wait before taking the snapshot however this is an arbitrary number which leads to non-deterministic results. 

We would like to propose that instead of waitBeforeScreenshots functioning as a delay only it should instead use the Puppeteer [waitFor](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagewaitforselectororfunctionortimeout-options-args) method. waitFor can be set as a number in milliseconds, a css selector or a function. This would give the ability to take the screen shot when the Story is in a known state.

Under the new API valid waitBeforeScreenshots values could be:
```
waitBeforeScreenshots: 500;
waitBeforeScreenshots: '.loaded';
waitBeforeScreenshots: () => window.__LOADED__ === true;
``` 

Because waitFor also accepts a number which functions as a delay this change would be backwards compatible with existing API.