### PR TITLE
Fix storybook 5 support

### DIFF
--- a/src/eyesStorybook.js
+++ b/src/eyesStorybook.js
@@ -15,7 +15,7 @@ const filterStories = require('./filterStories');
 const addVariationStories = require('./addVariationStories');
 const getStorybookBaseUrl = require('./getStorybookBaseUrl');
 
-const CONCURRENT_PAGES = 3;
+const CONCURRENT_PAGES = 1;
 
 async function eyesStorybook({config, logger, performance, timeItAsync}) {
   logger.log('eyesStorybook started');

--- a/src/getStories.js
+++ b/src/getStories.js
@@ -107,7 +107,7 @@ async function getStories() {
     return clientApi.raw().map(story => ({
       name: story.name,
       kind: story.kind,
-      parameters: story.parameters,
+      parameters: JSON.parse(JSON.stringify(story.parameters)),
     }));
   }
 


### PR DESCRIPTION
The [tutorial-storybook-react](https://github.com/applitools/tutorial-storybook-react) project and the [docs](https://applitools.com/tutorials/storybook-react.html#prerequisits) suggest to install the `v4.0.0-alpha.24` version of Storybook while the current version is the `5.1.10`.

I tried eyes-storybook the latest version of Storybook and it does not work. The reasons are the following:

- Storybook introduced a "lazy" loading of all the stories, it starts with a skeleton layout then it loads all the stories
- the `story.parameters` is no more serializable (from a Puppeteer perspective)

What I have done:

- I changed the `CONCURRENT_PAGES` constant from 3 to 1: the stories are not loaded (because of the "lazy" loading) if the page hosting Storybook is not in the foreground. The `CONCURRENT_PAGES` constant forces the first page (containing Storybook) in the background and the stories will not be loaded
- I serialized the `story.parameters` data: Puppeteer [reports that](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevaluatepagefunction-args)
  > If the function passed to the page.evaluate returns a non-[Serializable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) value, then page.evaluate resolves to `undefined`.

  the problem was that the stories were correctly found but, once the [`await page.evaluate(getStories);`](https://github.com/applitools/eyes-storybook/blob/master/src/eyesStorybook.js#L67) was run in Puppeteer, it returned `undefined`

Now everything works fine in Storybook 5 and the [tutorial-storybook-react](https://github.com/applitools/tutorial-storybook-react) could be updated.

Probably some more verifications are needed, I hope it could be useful to migrate eyes-storybook to the latest Storybook 5 😉